### PR TITLE
适配 @Extension 扩展属性

### DIFF
--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -1057,7 +1057,7 @@ SwaggerBootstrapUi.prototype.setDefaultSettings = function () {
 SwaggerBootstrapUi.prototype.openV3Settings = function (data) {
   var that = this;
   // 判断是否包含extensions的增强
-  var openapi = data['extensions'];
+  var openapi = KUtils.getExtensions(data);
   if (KUtils.checkUndefined(openapi)) {
     // 包含，判断settings
     if (KUtils.checkUndefined(openapi['x-setting'])) {
@@ -1138,7 +1138,7 @@ SwaggerBootstrapUi.prototype.openDocuments = function (data) {
 SwaggerBootstrapUi.prototype.openV3Documents = function (data) {
   var that = this;
   // 判断是否包含x-openapi的增强
-  var openapi = data['extensions'];
+  var openapi = KUtils.getExtensions(data);
   if (KUtils.checkUndefined(openapi)) {
     // 判断是否包含markdown文档
     if (KUtils.arrNotEmpty(openapi['x-markdownFiles'])) {
@@ -2468,8 +2468,8 @@ SwaggerBootstrapUi.prototype.analysisDefinition = function (menu) {
         tagorder = KUtils.getValue(tag, 'x-order', '', true);
       } else {
         // v3
-        if (KUtils.checkUndefined(tag['extensions'])) {
-          var tagexte = tag['extensions'];
+        if (KUtils.checkExtensionsUndefined(tag)) {
+          var tagexte = KUtils.getExtensions(tag);
           tagauth = KUtils.getValue(tagexte, 'x-author', '', true);
           tagorder = KUtils.getValue(tagexte, 'x-order', '', true);
         }
@@ -5077,8 +5077,8 @@ SwaggerBootstrapUi.prototype.readApiInfoInstanceExtOAS2 = function (swpinfo, api
  */
 SwaggerBootstrapUi.prototype.readApiInfoInstanceExtOAS3 = function (swpinfo, apiInfo) {
   // 获取扩展属性
-  if (apiInfo.hasOwnProperty('extensions') && KUtils.checkUndefined(apiInfo['extensions'])) {
-    var extensions = apiInfo['extensions'];
+  if (KUtils.checkExtensionsUndefined(apiInfo)) {
+    var extensions = KUtils.getExtensions(apiInfo);
     // 读取扩展属性x-ignoreParameters
     if (extensions.hasOwnProperty('x-ignoreParameters')) {
       var ignoArr = extensions['x-ignoreParameters'];

--- a/knife4j-vue3/src/core/utils.js
+++ b/knife4j-vue3/src/core/utils.js
@@ -798,7 +798,14 @@ const utils = {
       result += new Array((6 - tail) / 2 + 1).join("=");
     }
     return result;
-  }
+  },
+
+  checkExtensionsUndefined: function (obj) {
+    return obj && (this.checkUndefined(obj['extensions']) || this.checkUndefined(obj['x-extensions']))
+  },
+  getExtensions: function (obj) {
+    return this.checkExtensionsUndefined(obj) ? (obj['extensions'] || obj['x-extensions']) : undefined
+  },
 }
 
 


### PR DESCRIPTION
后台使用如下方式，即可为 @Tag 添加作者和排序码
@Tag(name = "用户管理", description = "用户的增删改查", extensions = {
        @Extension(name = "extensions", properties = {
                @ExtensionProperty(name = "x-author", value = "张三"),
                @ExtensionProperty(name = "x-order", value = "1000")
        })
})

使用如下方式，即可为 @Operation 添加排序码
@Operation(summary = "您好", description = "测试文档库", extensions = {
        @Extension(name = "extensions", properties = {
                @ExtensionProperty(name = "x-author", value = "李四"),
                @ExtensionProperty(name = "x-order", value = "1000")
        })
})